### PR TITLE
Added license header file so that every new file we add automatically gets the header

### DIFF
--- a/source/Conference/Conference.licenseheader
+++ b/source/Conference/Conference.licenseheader
@@ -1,0 +1,39 @@
+extensions: designer.cs
+extensions: .cs
+// ==============================================================================================================
+// Microsoft patterns & practices
+// CQRS Journey project
+// ==============================================================================================================
+// Copyright (c) Microsoft Corporation and contributors http://cqrsjourney.github.com/contributors/members
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance 
+// with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is 
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+// See the License for the specific language governing permissions and limitations under the License.
+// ==============================================================================================================
+extensions: .aspx .ascx
+<%-- 
+==============================================================================================================
+Microsoft patterns & practices
+CQRS Journey project
+==============================================================================================================
+Copyright (c) Microsoft Corporation and contributors http://cqrsjourney.github.com/contributors/members
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance 
+with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under the License is 
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and limitations under the License.
+==============================================================================================================
+--%>
+extensions: .vb
+' ==============================================================================================================
+' Microsoft patterns & practices
+' CQRS Journey project
+' ==============================================================================================================
+' Copyright (c) Microsoft Corporation and contributors http://cqrsjourney.github.com/contributors/members
+' Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance 
+' with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+' Unless required by applicable law or agreed to in writing, software distributed under the License is 
+' distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+' See the License for the specific language governing permissions and limitations under the License.
+' ==============================================================================================================

--- a/source/Conference/Conference.sln
+++ b/source/Conference/Conference.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Registration.Tests", "Regis
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A5323007-38D6-4578-A811-2C0BB55002BD}"
 	ProjectSection(SolutionItems) = preProject
+		Conference.licenseheader = Conference.licenseheader
 		install-packages.ps1 = install-packages.ps1
 	EndProjectSection
 EndProject

--- a/source/Conference/Core/Core.csproj
+++ b/source/Conference/Core/Core.csproj
@@ -50,6 +50,11 @@
     <Compile Include="IRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Conference.licenseheader">
+      <Link>Conference.licenseheader</Link>
+    </None>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/Conference/Registration.Tests/Registration.Tests.csproj
+++ b/source/Conference/Registration.Tests/Registration.Tests.csproj
@@ -71,6 +71,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\Conference.licenseheader">
+      <Link>Conference.licenseheader</Link>
+    </None>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/source/Conference/Registration/Registration.csproj
+++ b/source/Conference/Registration/Registration.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Reservation.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\Conference.licenseheader">
+      <Link>Conference.licenseheader</Link>
+    </None>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>


### PR DESCRIPTION
This is provided by the "License Header Manager" extension in the VS Gallery for those that want to install it.

Note that nobody needs to have the VSIX in order for the solution to work, compile, etc. It just makes it far easier to manage the headers at design-time (there's even a project-wide "Add header" thing to add it to any file that doesn't have it already). A must-have for me :)
