### PR TITLE
Cleanup of ServiceBus topics created by the integration tests

### DIFF
--- a/source/Conference/Azure/Azure.Common.IntegrationTests/BaseMessagingIntegration.cs
+++ b/source/Conference/Azure/Azure.Common.IntegrationTests/BaseMessagingIntegration.cs
@@ -29,7 +29,7 @@ namespace Azure.IntegrationTests
         public MessagingSettings Settings { get; private set; }
     }
 
-    public class given_a_topic_and_subscription : given_messaging_settings
+    public class given_a_topic_and_subscription : given_messaging_settings, IDisposable
     {
         public given_a_topic_and_subscription()
         {


### PR DESCRIPTION
Previously it was leaving a lot of topics in the subscription.
