### PR TITLE
Removed unnecessary SQL views

### DIFF
--- a/source/Conference/Conference.Web.Public.Tests/Controllers/RegistrationControllerFixture.cs
+++ b/source/Conference/Conference.Web.Public.Tests/Controllers/RegistrationControllerFixture.cs
@@ -35,7 +35,7 @@ namespace Conference.Web.Public.Tests.Controllers.RegistrationControllerFixture
         protected readonly ICommandBus bus;
         protected readonly IOrderDao orderDao;
         protected readonly IConferenceDao conferenceDao;
-        protected readonly ConferenceAliasDTO conferenceAlias = new ConferenceAliasDTO(Guid.NewGuid(), "TestConferenceCode", "Test Conference name");
+        protected readonly ConferenceAliasDTO conferenceAlias = new ConferenceAliasDTO { Id = Guid.NewGuid(), Code = "TestConferenceCode", Name = "Test Conference name" };
         protected readonly RouteCollection routes;
         protected readonly RouteData routeData;
         protected readonly Mock<HttpRequestBase> requestMock;
@@ -103,7 +103,8 @@ namespace Conference.Web.Public.Tests.Controllers.RegistrationControllerFixture
             var resultModel = result.Model as IList<ConferenceSeatTypeDTO>;
             Assert.NotNull(resultModel);
             Assert.Equal(1, resultModel.Count);
-            Assert.Equal("Test Seat", resultModel[0].Description);
+            Assert.Equal("Test Seat", resultModel[0].Name);
+            Assert.Equal("Description", resultModel[0].Description);
         }
 
         [Fact]

--- a/source/Conference/Conference.Web.Public.Tests/Controllers/ThirdPartyProcessorPaymentControllerFixture.cs
+++ b/source/Conference/Conference.Web.Public.Tests/Controllers/ThirdPartyProcessorPaymentControllerFixture.cs
@@ -34,7 +34,7 @@ namespace Conference.Web.Public.Tests.Controllers.ThirdPartyProcessorPaymentCont
             Assert.Equal(this.sut.ViewBag.ReturnUrl, "return");
             Assert.Equal(this.sut.ViewBag.CancelReturnUrl, "cancelreturn");
             Assert.Equal(this.sut.ViewBag.ItemName, "item");
-            Assert.Equal(this.sut.ViewBag.ItemAmount, 100d);
+            Assert.Equal(this.sut.ViewBag.ItemAmount, 100m);
 
         }
         [Fact]

--- a/source/Conference/Registration.Tests/ConferenceViewModelGeneratorFixture.cs
+++ b/source/Conference/Registration.Tests/ConferenceViewModelGeneratorFixture.cs
@@ -52,69 +52,6 @@ namespace Registration.Tests.ConferenceViewModelGeneratorFixture
     public class given_no_conference : given_a_database
     {
         [Fact]
-        public void when_conference_created_then_alias_dto_populated()
-        {
-            var conferenceId = Guid.NewGuid();
-
-            this.sut.Handle(new ConferenceCreated
-            {
-                Name = "name",
-                Description = "description",
-                Slug = "test",
-                Owner = new Owner
-                {
-                    Name = "owner",
-                    Email = "owner@email.com",
-                },
-                SourceId = conferenceId,
-                StartDate = DateTime.UtcNow.Date,
-                EndDate = DateTime.UtcNow.Date,
-            });
-
-            using (var context = new ConferenceRegistrationDbContext(dbName))
-            {
-                var dto = context.Find<ConferenceAliasDTO>(conferenceId);
-
-                Assert.NotNull(dto);
-                Assert.Equal("name", dto.Name);
-                Assert.Equal("test", dto.Code);
-            }
-
-        }
-
-        [Fact]
-        public void when_conference_created_then_description_dto_populated()
-        {
-            var conferenceId = Guid.NewGuid();
-
-            this.sut.Handle(new ConferenceCreated
-            {
-                Name = "name",
-                Description = "description",
-                Slug = "test",
-                Owner = new Owner
-                {
-                    Name = "owner",
-                    Email = "owner@email.com",
-                },
-                SourceId = conferenceId,
-                StartDate = DateTime.UtcNow.Date,
-                EndDate = DateTime.UtcNow.Date,
-            });
-
-            using (var context = new ConferenceRegistrationDbContext(dbName))
-            {
-                var dto = context.Find<ConferenceDescriptionDTO>(conferenceId);
-
-                Assert.NotNull(dto);
-                Assert.Equal("name", dto.Name);
-                Assert.Equal("description", dto.Description);
-                Assert.Equal("test", dto.Code);
-            }
-
-        }
-
-        [Fact]
         public void when_conference_created_then_conference_dto_populated()
         {
             var conferenceId = Guid.NewGuid();
@@ -170,67 +107,9 @@ namespace Registration.Tests.ConferenceViewModelGeneratorFixture
         }
 
         [Fact]
-        public void when_conference_updated_then_alias_dto_populated()
-        {
-            this.sut.Handle(new ConferenceUpdated
-            {
-                Name = "newname",
-                Description = "newdescription",
-                Slug = "newtest",
-                Owner = new Owner
-                {
-                    Name = "owner",
-                    Email = "owner@email.com",
-                },
-                SourceId = conferenceId,
-                StartDate = DateTime.UtcNow.Date,
-                EndDate = DateTime.UtcNow.Date,
-            });
-
-            using (var context = new ConferenceRegistrationDbContext(dbName))
-            {
-                var dto = context.Find<ConferenceAliasDTO>(conferenceId);
-
-                Assert.NotNull(dto);
-                Assert.Equal("newname", dto.Name);
-                Assert.Equal("newtest", dto.Code);
-            }
-
-        }
-
-        [Fact]
-        public void when_conference_updated_then_description_dto_populated()
-        {
-            this.sut.Handle(new ConferenceUpdated
-            {
-                Name = "newname",
-                Description = "newdescription",
-                Slug = "newtest",
-                Owner = new Owner
-                {
-                    Name = "owner",
-                    Email = "owner@email.com",
-                },
-                SourceId = conferenceId,
-                StartDate = DateTime.UtcNow.Date,
-                EndDate = DateTime.UtcNow.Date,
-            });
-
-            using (var context = new ConferenceRegistrationDbContext(dbName))
-            {
-                var dto = context.Find<ConferenceDescriptionDTO>(conferenceId);
-
-                Assert.NotNull(dto);
-                Assert.Equal("newname", dto.Name);
-                Assert.Equal("newdescription", dto.Description);
-                Assert.Equal("newtest", dto.Code);
-            }
-
-        }
-
-        [Fact]
         public void when_conference_updated_then_conference_dto_populated()
         {
+            var startDate = new DateTimeOffset(2012, 04, 20, 15, 0, 0, TimeSpan.FromHours(-8));
             this.sut.Handle(new ConferenceUpdated
             {
                 Name = "newname",
@@ -242,7 +121,7 @@ namespace Registration.Tests.ConferenceViewModelGeneratorFixture
                     Email = "owner@email.com",
                 },
                 SourceId = conferenceId,
-                StartDate = DateTime.UtcNow.Date,
+                StartDate = startDate.UtcDateTime,
                 EndDate = DateTime.UtcNow.Date,
             });
 
@@ -254,6 +133,7 @@ namespace Registration.Tests.ConferenceViewModelGeneratorFixture
                 Assert.Equal("newname", dto.Name);
                 Assert.Equal("newdescription", dto.Description);
                 Assert.Equal("newtest", dto.Code);
+                Assert.Equal(startDate, dto.StartDate);
                 Assert.Equal(0, dto.Seats.Count);
             }
         }

--- a/source/Conference/Registration/Handlers/ConferenceViewModelGenerator.cs
+++ b/source/Conference/Registration/Handlers/ConferenceViewModelGenerator.cs
@@ -40,9 +40,7 @@ namespace Registration.Handlers
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                repository.Set<ConferenceAliasDTO>().Add(new ConferenceAliasDTO(@event.SourceId, @event.Slug, @event.Name));
-                repository.Set<ConferenceDescriptionDTO>().Add(new ConferenceDescriptionDTO(@event.SourceId, @event.Slug, @event.Name, @event.Description));
-                repository.Set<ConferenceDTO>().Add(new ConferenceDTO(@event.SourceId, @event.Slug, @event.Name, @event.Description, Enumerable.Empty<ConferenceSeatTypeDTO>()));
+                repository.Set<ConferenceDTO>().Add(new ConferenceDTO(@event.SourceId, @event.Slug, @event.Name, @event.Description, @event.StartDate, Enumerable.Empty<ConferenceSeatTypeDTO>()));
 
                 repository.SaveChanges();
             }
@@ -52,28 +50,13 @@ namespace Registration.Handlers
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                var aliasDto = repository.Find<ConferenceAliasDTO>(@event.SourceId);
-                // TODO: replace with AutoMapper one-liner!
-                if (aliasDto != null)
-                {
-                    aliasDto.Code = @event.Slug;
-                    aliasDto.Name = @event.Name;
-                }
-
-                var descDto = repository.Find<ConferenceDescriptionDTO>(@event.SourceId);
-                if (descDto != null)
-                {
-                    descDto.Code = @event.Slug;
-                    descDto.Description = @event.Description;
-                    descDto.Name = @event.Name;
-                }
-
                 var confDto = repository.Find<ConferenceDTO>(@event.SourceId);
                 if (confDto != null)
                 {
                     confDto.Code = @event.Slug;
                     confDto.Description = @event.Description;
                     confDto.Name = @event.Name;
+                    confDto.StartDate = @event.StartDate;
                 }
 
                 repository.SaveChanges();
@@ -84,7 +67,7 @@ namespace Registration.Handlers
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                var dto = repository.Find<ConferenceAliasDTO>(@event.SourceId);
+                var dto = repository.Find<ConferenceDTO>(@event.SourceId);
                 if (dto != null)
                 {
                     dto.IsPublished = true;
@@ -98,7 +81,7 @@ namespace Registration.Handlers
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                var dto = repository.Find<ConferenceAliasDTO>(@event.SourceId);
+                var dto = repository.Find<ConferenceDTO>(@event.SourceId);
                 if (dto != null)
                 {
                     dto.IsPublished = false;

--- a/source/Conference/Registration/ReadModel/ConferenceAliasDTO.cs
+++ b/source/Conference/Registration/ReadModel/ConferenceAliasDTO.cs
@@ -14,25 +14,11 @@
 namespace Registration.ReadModel
 {
     using System;
-    using System.ComponentModel.DataAnnotations;
 
     public class ConferenceAliasDTO
     {
-        public ConferenceAliasDTO(Guid id, string code, string name)
-        {
-            this.Id = id;
-            this.Code = code;
-            this.Name = name;
-        }
-
-        protected ConferenceAliasDTO()
-        {
-        }
-
-        [Key]
         public Guid Id { get; set; }
         public string Code { get; set; }
         public string Name { get; set; }
-        public bool IsPublished { get; set; }
     }
 }

--- a/source/Conference/Registration/ReadModel/ConferenceDTO.cs
+++ b/source/Conference/Registration/ReadModel/ConferenceDTO.cs
@@ -20,12 +20,13 @@ namespace Registration.ReadModel
 
     public class ConferenceDTO
     {
-        public ConferenceDTO(Guid id, string code, string name, string description, IEnumerable<ConferenceSeatTypeDTO> seats)
+        public ConferenceDTO(Guid id, string code, string name, string description, DateTimeOffset startDate, IEnumerable<ConferenceSeatTypeDTO> seats)
         {
             this.Id = id;
             this.Code = code;
             this.Name = name;
             this.Description = description;
+            this.StartDate = startDate;
             this.Seats = new ObservableCollection<ConferenceSeatTypeDTO>(seats);
         }
 
@@ -39,6 +40,9 @@ namespace Registration.ReadModel
         public string Code { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public DateTimeOffset StartDate { get; set; }
         public ICollection<ConferenceSeatTypeDTO> Seats { get; set; }
+
+        public bool IsPublished { get; set; }
     }
 }

--- a/source/Conference/Registration/ReadModel/ConferenceDescriptionDTO.cs
+++ b/source/Conference/Registration/ReadModel/ConferenceDescriptionDTO.cs
@@ -14,26 +14,13 @@
 namespace Registration.ReadModel
 {
     using System;
-    using System.ComponentModel.DataAnnotations;
 
     public class ConferenceDescriptionDTO
     {
-        public ConferenceDescriptionDTO(Guid id, string code, string name, string description)
-        {
-            this.Id = id;
-            this.Code = code;
-            this.Name = name;
-            this.Description = description;
-        }
-
-        protected ConferenceDescriptionDTO()
-        {
-        }
-
-        [Key]
         public Guid Id { get; set; }
         public string Code { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public DateTimeOffset StartDate { get; set; }
     }
 }

--- a/source/Conference/Registration/ReadModel/Implementation/ConferenceDao.cs
+++ b/source/Conference/Registration/ReadModel/Implementation/ConferenceDao.cs
@@ -30,16 +30,23 @@ namespace Registration.ReadModel.Implementation
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                return repository.Query<ConferenceDescriptionDTO>().Where(dto => dto.Code == conferenceCode).FirstOrDefault();
+                return repository
+                    .Query<ConferenceDTO>()
+                    .Where(dto => dto.Code == conferenceCode)
+                    .Select(x => new ConferenceDescriptionDTO { Id = x.Id, Code = x.Code, Name = x.Name, Description = x.Description, StartDate = x.StartDate })
+                    .FirstOrDefault();
             }
         }
 
         public ConferenceAliasDTO GetConferenceAlias(string conferenceCode)
         {
-            // NOTE: Could even use a dynamically generated projection (from the already denormailized read model DB) at this point.
             using (var repository = this.contextFactory.Invoke())
             {
-                return repository.Query<ConferenceAliasDTO>().Where(dto => dto.Code == conferenceCode).FirstOrDefault();
+                return repository
+                    .Query<ConferenceDTO>()
+                    .Where(dto => dto.Code == conferenceCode)
+                    .Select(x => new ConferenceAliasDTO { Id = x.Id, Code = x.Code, Name = x.Name })
+                    .FirstOrDefault();
             }
         }
 
@@ -47,7 +54,11 @@ namespace Registration.ReadModel.Implementation
         {
             using (var repository = this.contextFactory.Invoke())
             {
-                return repository.Query<ConferenceAliasDTO>().Where(c => c.IsPublished).ToList();
+                return repository
+                    .Query<ConferenceDTO>()
+                    .Where(dto => dto.IsPublished)
+                    .Select(x => new ConferenceAliasDTO { Id = x.Id, Code = x.Code, Name = x.Name })
+                    .ToList();
             }
         }
 

--- a/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContext.cs
+++ b/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContext.cs
@@ -44,8 +44,6 @@ namespace Registration.ReadModel.Implementation
             modelBuilder.Entity<ConferenceDTO>().ToTable("ConferencesView");
             modelBuilder.Entity<ConferenceDTO>().HasMany(c => c.Seats).WithRequired().Map(c => c.MapKey("ConferencesView_Id"));
             modelBuilder.Entity<ConferenceSeatTypeDTO>().ToTable("ConferenceSeatsView");
-            modelBuilder.Entity<ConferenceAliasDTO>().ToTable("ConferenceAliasesView");
-            modelBuilder.Entity<ConferenceDescriptionDTO>().ToTable("ConferenceDescriptionsView");
         }
 
         public T Find<T>(Guid id) where T : class

--- a/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContextInitializer.cs
+++ b/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContextInitializer.cs
@@ -49,13 +49,17 @@ Sed ac nibh mauris. Curabitur et purus odio, vitae iaculis augue. Donec sceleris
 
 Quisque pellentesque, est volutpat viverra tristique, erat enim tincidunt risus, vel consectetur nulla quam et justo. Ut nec condimentum felis. Vivamus bibendum risus ut nibh scelerisque eget sodales purus tincidunt. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse non libero ante. Mauris felis dolor, aliquam vitae luctus vel, elementum in mauris. Donec a risus purus. Fusce sit amet lobortis velit. Nam lacinia sagittis fermentum. Nulla sapien erat, cursus a porta non, malesuada ut erat. Vivamus pharetra erat eu metus varius vel placerat nunc interdum. Sed tristique, risus eu sollicitudin aliquam, nibh purus rhoncus dolor, in elementum arcu orci eu lorem. Cras a diam mattis nisl laoreet tempus quis in nunc. Aliquam erat volutpat.";
 
-                context.Set<ConferenceDTO>().Add(new ConferenceDTO(Guid.Empty, "pnpsymposium", "P&P Symposium", description, new[]
-                {
-                    new ConferenceSeatTypeDTO(new Guid("38D8710D-AEF6-4158-950D-3F75CC4BEE0B"), "Test Seat", "Test Description", 10),
-                }));
-
-                context.Set<ConferenceAliasDTO>().Add(new ConferenceAliasDTO(Guid.Empty, "pnpsymposium", "P&P Symposium") { IsPublished = true });
-                context.Set<ConferenceDescriptionDTO>().Add(new ConferenceDescriptionDTO(Guid.Empty, "pnpsymposium", "P&P Symposium", description));
+                context.Set<ConferenceDTO>().Add(
+                    new ConferenceDTO(
+                        Guid.Empty,
+                        "pnpsymposium", 
+                        "P&P Symposium",
+                        description, 
+                        DateTimeOffset.UtcNow.AddMonths(2),
+                        new[] { new ConferenceSeatTypeDTO(new Guid("38D8710D-AEF6-4158-950D-3F75CC4BEE0B"), "Test Seat", "Test Description", 10) })
+                        {
+                            IsPublished = true
+                        });
             }
 
             context.SaveChanges();


### PR DESCRIPTION
It was actually using separate tables in the last pull request, which was just duping data for no reason.
Projection handled at DAO, to avoid painful SQL scripts, which were actually very unnecessary in this case.
