### PR TITLE
Moved responsibility of disposing message to the actual message sender

### DIFF
--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/CommandBus.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/CommandBus.cs
@@ -46,28 +46,15 @@ namespace Infrastructure.Azure.Messaging
         public void Send(Envelope<ICommand> command)
         {
             var message = BuildMessage(command);
-            try
-            {
-                this.sender.Send(message);
-            }
-            finally
-            {
-                message.Dispose();
-            }
+
+            this.sender.Send(message);
         }
 
         public void Send(IEnumerable<Envelope<ICommand>> commands)
         {
-            var messages = commands.Select(command => BuildMessage(command)).ToList();
+            var messages = commands.Select(command => BuildMessage(command));
 
-            try
-            {
-                this.sender.Send(messages);
-            }
-            finally
-            {
-                messages.ForEach(message => message.Dispose());
-            }
+            this.sender.Send(messages);
         }
 
         private BrokeredMessage BuildMessage(Envelope<ICommand> command)

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/EventBus.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/EventBus.cs
@@ -50,14 +50,7 @@ namespace Infrastructure.Azure.Messaging
         {
             var message = BuildMessage(@event);
 
-            try
-            {
-                this.sender.Send(message);
-            }
-            finally
-            {
-                message.Dispose();
-            }
+            this.sender.Send(message);
         }
 
         /// <summary>
@@ -65,16 +58,9 @@ namespace Infrastructure.Azure.Messaging
         /// </summary>
         public void Publish(IEnumerable<IEvent> events)
         {
-            var messages = events.Select(e => BuildMessage(e)).ToList();
+            var messages = events.Select(e => BuildMessage(e));
 
-            try
-            {
-                this.sender.Send(messages);
-            }
-            finally
-            {
-                messages.ForEach(message => message.Dispose());
-            }
+            this.sender.Send(messages);
         }
 
         private BrokeredMessage BuildMessage(IEvent @event)

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/TopicSender.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/TopicSender.cs
@@ -65,12 +65,16 @@ namespace Infrastructure.Azure.Messaging
 
             // TODO: what about retries? Watch-out for message reuse. Need to recreate it before retry.
             // Always send async.
-            client.Async(message, client.BeginSend, client.EndSend);
+            client.BeginSend(message, ar =>
+            {
+                client.EndSend(ar);
+                message.Dispose();
+            }, null);
         }
 
         public void Send(IEnumerable<BrokeredMessage> messages)
         {
-            // TODO: batch/transactional sending? Is it just wrapping with a TransactionScope?
+            // TODO: batch/transactional sending?
             foreach (var message in messages)
             {
                 this.Send(message);


### PR DESCRIPTION
...not the buses. This allows the sender to still do async and dispose at the right time.
#219
