### PR TITLE
Updated database initializer project so that it's a bit smarter 

### DIFF
--- a/source/Conference.sln
+++ b/source/Conference.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Registration.Tests", "Confe
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A5323007-38D6-4578-A811-2C0BB55002BD}"
 	ProjectSection(SolutionItems) = preProject
+		..\scripts\CreateDatabaseObjects.sql = ..\scripts\CreateDatabaseObjects.sql
 		..\install-packages.ps1 = ..\install-packages.ps1
 	EndProjectSection
 EndProject

--- a/source/DatabaseInitializer/App.config
+++ b/source/DatabaseInitializer/App.config
@@ -4,6 +4,9 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
   </configSections>
+  <appSettings>
+    <add key="defaultConnection" value="Data Source=.\sqlexpress;Initial Catalog=conference;Integrated Security=True"/>
+  </appSettings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework">
       <parameters>

--- a/source/DatabaseInitializer/DatabaseInitializer.csproj
+++ b/source/DatabaseInitializer/DatabaseInitializer.csproj
@@ -55,6 +55,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Knows how to drop and recreate the database as needed.

Also added a default connection string, which equals the one we use in the web projects (no need to supply one now).
Running the initializer multiple times just works and recreates the DB.
