### PR TITLE
Consistently use aggregate-type+id as the key for events in both Azure and SQL store

### DIFF
--- a/source/Infrastructure/Sql/Infrastructure.Sql/EventSourcing/EventStoreDbContext.cs
+++ b/source/Infrastructure/Sql/Infrastructure.Sql/EventSourcing/EventStoreDbContext.cs
@@ -29,13 +29,14 @@ namespace Infrastructure.Sql.EventSourcing
         {
             base.OnModelCreating(modelBuilder);
 
-            modelBuilder.Entity<Event>().HasKey(x => new { x.AggregateId, x.Version }).ToTable("Events", SchemaName);
+            modelBuilder.Entity<Event>().HasKey(x => new { x.AggregateId, x.AggregateType, x.Version }).ToTable("Events", SchemaName);
         }
     }
 
     public class Event
     {
         public Guid AggregateId { get; set; }
+        public string AggregateType { get; set; }
         public int Version { get; set; }
         public string Payload { get; set; }
 


### PR DESCRIPTION
Fixes issue #261
