### PR TITLE
reduce the level of trace messages

### DIFF
--- a/source/Conference/Registration/RegistrationProcessRouter.cs
+++ b/source/Conference/Registration/RegistrationProcessRouter.cs
@@ -107,7 +107,7 @@ namespace Registration
                     }
                     else
                     {
-                        Trace.TraceError("Failed to locate the registration process to expire with id {0}.", command.ProcessId);
+                        Trace.TraceInformation("Failed to locate the registration process to expire with id {0}.", command.ProcessId);
                     }
                 }
             }

--- a/source/WorkerRoleCommandProcessor/WorkerRole.cs
+++ b/source/WorkerRoleCommandProcessor/WorkerRole.cs
@@ -40,7 +40,6 @@ namespace WorkerRoleCommandProcessor
                 while (this.running)
                 {
                     Thread.Sleep(10000);
-                    Trace.WriteLine("Command processor working", "Information");
                 }
 
                 processor.Stop();


### PR DESCRIPTION
Cannot make the message when failing to find the process to expire verbose without changing the method used. Left as information.
