### PR TITLE
#392 Increased buffer time before releasing seats 

### DIFF
--- a/source/Conference/Registration.Tests/RegistrationProcessFixture.cs
+++ b/source/Conference/Registration.Tests/RegistrationProcessFixture.cs
@@ -133,7 +133,7 @@ namespace Registration.Tests.RegistrationProcessFixture.given_process_awaiting_f
         {
             var expirationCommandEnvelope = this.sut.Commands.Where(e => e.Body is ExpireRegistrationProcess).Single();
 
-            Assert.True(expirationCommandEnvelope.Delay > TimeSpan.FromMinutes(10));
+            Assert.True(expirationCommandEnvelope.Delay > TimeSpan.FromMinutes(32));
             Assert.Equal(((ExpireRegistrationProcess)expirationCommandEnvelope.Body).ProcessId, this.sut.Id);
         }
     }

--- a/source/Conference/Registration/RegistrationProcess.cs
+++ b/source/Conference/Registration/RegistrationProcess.cs
@@ -25,6 +25,8 @@ namespace Registration
 
     public class RegistrationProcess : IProcess
     {
+        private static readonly TimeSpan BufferTimeBeforeReleasingSeatsAfterExpiration = TimeSpan.FromMinutes(14);
+
         public enum ProcessState
         {
             NotStarted = 0,
@@ -118,14 +120,12 @@ namespace Registration
 
                 if (this.ExpirationCommandId == Guid.Empty)
                 {
-                    var bufferTime = TimeSpan.FromMinutes(5);
-
                     var expirationCommand = new ExpireRegistrationProcess { ProcessId = this.Id };
                     this.ExpirationCommandId = expirationCommand.Id;
 
                     this.AddCommand(new Envelope<ICommand>(expirationCommand)
                     {
-                        Delay = expirationTime.Subtract(DateTime.UtcNow).Add(bufferTime),
+                        Delay = expirationTime.Subtract(DateTime.UtcNow).Add(BufferTimeBeforeReleasingSeatsAfterExpiration),
                     });
                 }
 


### PR DESCRIPTION
To account for user taking too much time to pay in the third party payment site.
