### PR TITLE
Read models assume messages will be ordered for the same SourceId. I

### DIFF
--- a/source/Conference/Registration.IntegrationTests/PricedOrderViewModelGeneratorFixture.cs
+++ b/source/Conference/Registration.IntegrationTests/PricedOrderViewModelGeneratorFixture.cs
@@ -71,7 +71,8 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
                         },
                     },
                     Total = 50,
-                    IsFreeOfCharge = true
+                    IsFreeOfCharge = true,
+                    Version = 4,
                 });
 
                 this.dto = this.dao.FindPricedOrder(orderId);
@@ -81,6 +82,7 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
             public void then_creates_model()
             {
                 Assert.NotNull(dto);
+                Assert.Equal(4, dto.OrderVersion);
             }
 
             [Fact]
@@ -96,7 +98,7 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
             [Fact]
             public void then_populates_description()
             {
-                Assert.Equal("General", dto.Lines[0].Description);
+                Assert.Contains("General", dto.Lines.Select(x => x.Description));
             }
 
             [Fact]
@@ -122,6 +124,7 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
                         },
                     },
                     Total = 20,
+                    Version = 8,
                 });
 
                 var dto = this.dao.FindPricedOrder(orderId);
@@ -131,7 +134,8 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
                 Assert.Equal(2, dto.Lines[0].Quantity);
                 Assert.Equal(10, dto.Lines[0].UnitPrice);
                 Assert.Equal(20, dto.Total);
-                Assert.Equal("Precon", dto.Lines[0].Description);
+                Assert.Contains("Precon", dto.Lines.Select(x => x.Description));
+                Assert.Equal(8, dto.OrderVersion);
             }
 
             [Fact]
@@ -148,11 +152,17 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
             public void when_seat_assignments_created_then_updates_order_with_assignments_id()
             {
                 var assignmentsId = Guid.NewGuid();
-                this.sut.Handle(new SeatAssignmentsCreated { SourceId = assignmentsId, OrderId = orderId });
+                this.sut.Handle(new SeatAssignmentsCreated
+                                    {
+                                        SourceId = assignmentsId, 
+                                        OrderId = orderId,
+                                        Version = 9,
+                                    });
 
                 var dto = this.dao.FindPricedOrder(orderId);
 
                 Assert.Equal(assignmentsId, dto.AssignmentsId);
+                Assert.Equal(9, dto.OrderVersion);
             }
         }
 
@@ -199,7 +209,8 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
                         },
                     },
                     Total = 60,
-                    IsFreeOfCharge = true
+                    IsFreeOfCharge = true,
+                    Version = 9,
                 });
 
                 this.dto = this.dao.FindPricedOrder(orderId);
@@ -208,8 +219,8 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
             [Fact]
             public void then_populates_with_updated_description()
             {
-                Assert.True(dto.Lines.Any(x => x.Description == "General_Updated"));
-                Assert.True(dto.Lines.Any(x => x.Description == "Precon"));
+                Assert.Contains("General_Updated", dto.Lines.Select(x => x.Description));
+                Assert.Contains("Precon_Updated", dto.Lines.Select(x => x.Description));
             }
 
             [Fact]
@@ -237,12 +248,13 @@ namespace Registration.IntegrationTests.PricedOrderViewModelGeneratorFixture
                         },
                     },
                     Total = 30,
+                    Version = 12,
                 });
 
                 var dto = this.dao.FindPricedOrder(orderId);
 
-                Assert.True(dto.Lines.Any(x => x.Description == "General_Updated"));
-                Assert.True(dto.Lines.Any(x => x.Description == "Precon_Updated"));
+                Assert.Contains("General_Updated", dto.Lines.Select(x => x.Description));
+                Assert.Contains("Precon_Updated", dto.Lines.Select(x => x.Description));
             }
         }
     }

--- a/source/Conference/Registration.IntegrationTests/SeatAssignmentsViewModelGeneratorFixture.cs
+++ b/source/Conference/Registration.IntegrationTests/SeatAssignmentsViewModelGeneratorFixture.cs
@@ -44,7 +44,7 @@ namespace Registration.IntegrationTests.SeatAssignmentsViewModelGeneratorFixture
 
             var blobs = new MemoryBlobStorage();
             this.dao = new OrderDao(() => new ConferenceRegistrationDbContext(dbName), blobs, new JsonTextSerializer());
-            this.sut = new SeatAssignmentsViewModelGenerator(conferenceDao.Object, this.dao, blobs, new JsonTextSerializer());
+            this.sut = new SeatAssignmentsViewModelGenerator(conferenceDao.Object, blobs, new JsonTextSerializer());
 
             this.sut.Handle(new SeatAssignmentsCreated
             {

--- a/source/Conference/Registration/Handlers/SeatAssignmentsViewModelGenerator.cs
+++ b/source/Conference/Registration/Handlers/SeatAssignmentsViewModelGenerator.cs
@@ -15,7 +15,6 @@ namespace Registration.Handlers
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -26,7 +25,6 @@ namespace Registration.Handlers
     using Registration.Events;
     using Registration.ReadModel;
 
-    // TODO: should work correctly with out of order messages instead of dropping events!
     public class SeatAssignmentsViewModelGenerator :
         IEventHandler<SeatAssignmentsCreated>,
         IEventHandler<SeatAssigned>,
@@ -35,17 +33,14 @@ namespace Registration.Handlers
     {
         private readonly IBlobStorage storage;
         private readonly ITextSerializer serializer;
-        private IConferenceDao conferenceDao;
-        private IOrderDao orderDao;
+        private readonly IConferenceDao conferenceDao;
 
         public SeatAssignmentsViewModelGenerator(
             IConferenceDao conferenceDao,
-            IOrderDao orderDao,
             IBlobStorage storage,
             ITextSerializer serializer)
         {
             this.conferenceDao = conferenceDao;
-            this.orderDao = orderDao;
             this.storage = storage;
             this.serializer = serializer;
         }
@@ -70,67 +65,25 @@ namespace Registration.Handlers
         public void Handle(SeatAssigned @event)
         {
             var dto = Find(@event.SourceId);
-            if (dto != null)
-            {
-                var seat = dto.Seats.FirstOrDefault(x => x.Position == @event.Position);
-                if (seat != null)
-                {
-                    Mapper.Map(@event, seat);
-                    Save(dto);
-                }
-                else
-                {
-                    Trace.TraceError("Failed to locate the seat at position {0} being assigned.", @event.Position);
-                }
-            }
-            else
-            {
-                Trace.TraceError("Failed to locate the order seats assignments read model corresponding to the assigned seat, assignments id {0}.", @event.SourceId);
-            }
+            var seat = dto.Seats.First(x => x.Position == @event.Position);
+            Mapper.Map(@event, seat);
+            Save(dto);
         }
 
         public void Handle(SeatUnassigned @event)
         {
             var dto = Find(@event.SourceId);
-            if (dto != null)
-            {
-                var seat = dto.Seats.FirstOrDefault(x => x.Position == @event.Position);
-                if (seat != null)
-                {
-                    seat.Attendee.Email = seat.Attendee.FirstName = seat.Attendee.LastName = null;
-                    Save(dto);
-                }
-                else
-                {
-                    Trace.TraceError("Failed to locate the seat at position {0} being unassigned.", @event.Position);
-                }
-            }
-            else
-            {
-                Trace.TraceError("Failed to locate the order seats assignments read model corresponding to the unassigned seat, assignments id {0}.", @event.SourceId);
-            }
+            var seat = dto.Seats.First(x => x.Position == @event.Position);
+            seat.Attendee.Email = seat.Attendee.FirstName = seat.Attendee.LastName = null;
+            Save(dto);
         }
 
         public void Handle(SeatAssignmentUpdated @event)
         {
             var dto = Find(@event.SourceId);
-            if (dto != null)
-            {
-                var seat = dto.Seats.FirstOrDefault(x => x.Position == @event.Position);
-                if (seat != null)
-                {
-                    Mapper.Map(@event, seat);
-                    Save(dto);
-                }
-                else
-                {
-                    Trace.TraceError("Failed to locate the seat at position {0} being updated.", @event.Position);
-                }
-            }
-            else
-            {
-                Trace.TraceError("Failed to locate the order seats assignments read model corresponding to the updated seat, assignments id {0}.", @event.SourceId);
-            }
+            var seat = dto.Seats.First(x => x.Position == @event.Position);
+            Mapper.Map(@event, seat);
+            Save(dto);
         }
 
         private OrderSeats Find(Guid id)


### PR DESCRIPTION
f there is an issue, throws, as there should be only one EventHandler per subscription.
This pull request is dependent on #394, so merge only when there is already just a single event handler per subscription, otherwise throwing an exception my corrupt other read models.
