### PR TITLE
Removed message payload tracing

### DIFF
--- a/source/Infrastructure/Azure/Infrastructure.Azure.IntegrationTests/MessageProcessorIntegration.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure.IntegrationTests/MessageProcessorIntegration.cs
@@ -105,7 +105,7 @@ namespace Infrastructure.Azure.IntegrationTests.MessageProcessorIntegration
             this.waiter = waiter;
         }
 
-        protected override void ProcessMessage(object payload)
+        protected override void ProcessMessage(string traceIdentifier, object payload)
         {
             this.Payload = payload;
 

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/CommandProcessor.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/CommandProcessor.cs
@@ -16,7 +16,6 @@ namespace Infrastructure.Azure.Messaging.Handling
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.IO;
     using System.Linq;
     using Infrastructure.Azure.Messaging;
     using Infrastructure.Messaging.Handling;
@@ -66,14 +65,14 @@ namespace Infrastructure.Azure.Messaging.Handling
         /// <summary>
         /// Processes the message by calling the registered handler.
         /// </summary>
-        protected override void ProcessMessage(object payload)
+        protected override void ProcessMessage(string traceIdentifier, object payload)
         {
             var commandType = payload.GetType();
             ICommandHandler handler = null;
 
             if (this.handlers.TryGetValue(commandType, out handler))
             {
-                Trace.WriteLine("-- Handled by " + handler.GetType().FullName);
+                Trace.WriteLine("-- Handled by " + handler.GetType().FullName + traceIdentifier);
                 ((dynamic)handler).Handle((dynamic)payload);
             }
         }

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/EventProcessor.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/EventProcessor.cs
@@ -42,14 +42,14 @@ namespace Infrastructure.Azure.Messaging.Handling
             this.handlers.Add(eventHandler);
         }
 
-        protected override void ProcessMessage(object payload)
+        protected override void ProcessMessage(string traceIdentifier, object payload)
         {
             var handlerType = typeof(IEventHandler<>).MakeGenericType(payload.GetType());
 
             foreach (dynamic handler in this.handlers
                 .Where(x => handlerType.IsAssignableFrom(x.GetType())))
             {
-                Trace.WriteLine("-- Handled by " + ((object)handler).GetType().FullName);
+                Trace.WriteLine("-- Handled by " + ((object)handler).GetType().FullName + traceIdentifier);
                 handler.Handle((dynamic)payload);
             }
         }

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/MessageProcessor.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/Handling/MessageProcessor.cs
@@ -89,7 +89,12 @@ namespace Infrastructure.Azure.Messaging.Handling
             GC.SuppressFinalize(this);
         }
 
-        protected abstract void ProcessMessage(object payload);
+        /// <summary>
+        /// Processes the message.
+        /// </summary>
+        /// <param name="traceIdentifier">The identifier that can be used to track the source message in the logs.</param>
+        /// <param name="payload">The typed message payload.</param>
+        protected abstract void ProcessMessage(string traceIdentifier, object payload);
 
         /// <summary>
         /// Disposes the resources used by the processor.
@@ -134,7 +139,7 @@ namespace Infrastructure.Azure.Messaging.Handling
             string traceIdentifier = BuildTraceIdentifier(message);
             try
             {
-                ProcessMessage(payload);
+                ProcessMessage(traceIdentifier, payload);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Still need to figure out where to add payload tracing to the output window when debugging from VS. But for now, we have to scan the message log to retrieve it.
