### PR TITLE
Make message processor resilient to serialization exceptions.

### DIFF
--- a/source/Infrastructure/Infrastructure/Serialization/JsonTextSerializer.cs
+++ b/source/Infrastructure/Infrastructure/Serialization/JsonTextSerializer.cs
@@ -14,6 +14,7 @@
 namespace Infrastructure.Serialization
 {
     using System.IO;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     public class JsonTextSerializer : ITextSerializer
@@ -53,7 +54,15 @@ namespace Infrastructure.Serialization
         {
             var jsonReader = new JsonTextReader(reader);
 
-            return this.serializer.Deserialize(jsonReader);
+            try
+            {
+                return this.serializer.Deserialize(jsonReader);
+            }
+            catch (JsonSerializationException e)
+            {
+                // Wrap in a standard .NET exception.
+                throw new SerializationException(e.Message, e);
+            }
         }
     }
 }


### PR DESCRIPTION
For now just dead-letter the message immediately. In the future, maybe hook custom handling (i.e. upgrading, ignoring?) for versioning scenario.
Fixes #443
