### PR TITLE
rename the perf counter category to avoid publishing issues

### DIFF
--- a/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/Constants.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/Constants.cs
@@ -15,7 +15,7 @@ namespace Infrastructure.Azure.Instrumentation
 {
     public static class Constants
     {
-        public const string ReceiversPerformanceCountersCategory = "Azure Infrastructure (Receivers)";
-        public const string EventPublishersPerformanceCountersCategory = "Azure Infrastructure (Event Publishers)";
+        public const string ReceiversPerformanceCountersCategory = "Azure Infrastructure - Receivers";
+        public const string EventPublishersPerformanceCountersCategory = "Azure Infrastructure - Event Publishers";
     }
 }


### PR DESCRIPTION
Azure's perf counter publishing got confused by the parenthesis in the category names
