### PR TITLE
reset instrumentation counters at startup

### DIFF
--- a/source/Conference/Conference.Web.Public/Global.asax.Azure.cs
+++ b/source/Conference/Conference.Web.Public/Global.asax.Azure.cs
@@ -94,7 +94,7 @@ namespace Conference.Web.Public
 
             container.RegisterInstance<IEventStore>(eventStore);
             container.RegisterInstance<IPendingEventsQueue>(eventStore);
-            container.RegisterInstance<IEventStoreBusPublisherInstrumentation>(new EventStoreBusPublisherInstrumentation(instrumentationEnabled));
+            container.RegisterInstance<IEventStoreBusPublisherInstrumentation>(new EventStoreBusPublisherInstrumentation("web.public", instrumentationEnabled));
             container.RegisterType<IEventStoreBusPublisher, EventStoreBusPublisher>(new ContainerControlledLifetimeManager());
             container.RegisterType(
                 typeof(IEventSourcedRepository<>),

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/AzureInstrumentationInstaller.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/AzureInstrumentationInstaller.cs
@@ -47,7 +47,7 @@ namespace Infrastructure.Azure.Instrumentation
 
             // Event store publisher counters
             {
-                var installer = new PerformanceCounterInstaller { CategoryName = Constants.EventPublishersPerformanceCountersCategory, CategoryType = PerformanceCounterCategoryType.SingleInstance };
+                var installer = new PerformanceCounterInstaller { CategoryName = Constants.EventPublishersPerformanceCountersCategory, CategoryType = PerformanceCounterCategoryType.MultiInstance };
                 this.Installers.Add(installer);
 
 

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/EventStoreBusPublisherInstrumentation.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/EventStoreBusPublisherInstrumentation.cs
@@ -32,17 +32,23 @@ namespace Infrastructure.Azure.Instrumentation
         private readonly PerformanceCounter eventsPublishedPerSecondCounter;
         private readonly PerformanceCounter totalEventsPublishedCounter;
 
-        public EventStoreBusPublisherInstrumentation(bool instrumentationEnabled)
+        public EventStoreBusPublisherInstrumentation(string instanceName, bool instrumentationEnabled)
         {
             this.instrumentationEnabled = instrumentationEnabled;
 
             if (this.instrumentationEnabled)
             {
-                this.currentEventPublishersCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, CurrentEventPublishersCounterName, false);
-                this.totalEventsPublishingRequestedCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, TotalEventsPublishingRequestsCounterName, false);
-                this.eventPublishingRequestsPerSecondCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, EventPublishingRequestsPerSecondCounterName, false);
-                this.totalEventsPublishedCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, TotalEventsPublishedCounterName, false);
-                this.eventsPublishedPerSecondCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, EventsPublishedPerSecondCounterName, false);
+                this.currentEventPublishersCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, CurrentEventPublishersCounterName, instanceName, false);
+                this.totalEventsPublishingRequestedCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, TotalEventsPublishingRequestsCounterName, instanceName, false);
+                this.eventPublishingRequestsPerSecondCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, EventPublishingRequestsPerSecondCounterName, instanceName, false);
+                this.totalEventsPublishedCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, TotalEventsPublishedCounterName, instanceName, false);
+                this.eventsPublishedPerSecondCounter = new PerformanceCounter(Constants.EventPublishersPerformanceCountersCategory, EventsPublishedPerSecondCounterName, instanceName, false);
+
+                this.currentEventPublishersCounter.RawValue = 0;
+                this.totalEventsPublishingRequestedCounter.RawValue = 0;
+                this.eventPublishingRequestsPerSecondCounter.RawValue = 0;
+                this.totalEventsPublishedCounter.RawValue = 0;
+                this.eventsPublishedPerSecondCounter.RawValue = 0;
             }
         }
 

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/SessionSubscriptionReceiverInstrumentation.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/SessionSubscriptionReceiverInstrumentation.cs
@@ -31,6 +31,9 @@ namespace Infrastructure.Azure.Instrumentation
             {
                 this.totalSessionsCounter = new PerformanceCounter(Constants.ReceiversPerformanceCountersCategory, TotalSessionsCounterName, this.InstanceName, false);
                 this.currentSessionsCounter = new PerformanceCounter(Constants.ReceiversPerformanceCountersCategory, CurrentSessionsCounterName, this.InstanceName, false);
+
+                this.totalSessionsCounter.RawValue = 0;
+                this.currentSessionsCounter.RawValue = 0;
             }
         }
 

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/SubscriptionReceiverInstrumentation.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Instrumentation/SubscriptionReceiverInstrumentation.cs
@@ -57,6 +57,15 @@ namespace Infrastructure.Azure.Instrumentation
                 this.averageMessageProcessingTimeCounter = new PerformanceCounter(Constants.ReceiversPerformanceCountersCategory, AverageMessageProcessingTimeCounterName, this.instanceName, false);
                 this.averageMessageProcessingTimeBaseCounter = new PerformanceCounter(Constants.ReceiversPerformanceCountersCategory, AverageMessageProcessingTimeBaseCounterName, this.instanceName, false);
                 this.currentMessagesInProcessCounter = new PerformanceCounter(Constants.ReceiversPerformanceCountersCategory, CurrentMessagesInProcessCounterName, this.instanceName, false);
+
+                this.totalMessagesCounter.RawValue = 0;
+                this.totalMessagesSuccessfullyProcessedCounter.RawValue = 0;
+                this.totalMessagesUnsuccessfullyProcessedCounter.RawValue = 0;
+                this.totalMessagesCompletedCounter.RawValue = 0;
+                this.totalMessagesNotCompletedCounter.RawValue = 0;
+                this.averageMessageProcessingTimeCounter.RawValue = 0;
+                this.averageMessageProcessingTimeBaseCounter.RawValue = 0;
+                this.currentMessagesInProcessCounter.RawValue = 0;
             }
         }
 

--- a/source/WorkerRoleCommandProcessor/ConferenceProcessor.Azure.cs
+++ b/source/WorkerRoleCommandProcessor/ConferenceProcessor.Azure.cs
@@ -135,7 +135,7 @@ namespace WorkerRoleCommandProcessor
 
             container.RegisterInstance<IEventStore>(eventStore);
             container.RegisterInstance<IPendingEventsQueue>(eventStore);
-            container.RegisterInstance<IEventStoreBusPublisherInstrumentation>(new EventStoreBusPublisherInstrumentation(this.instrumentationEnabled));
+            container.RegisterInstance<IEventStoreBusPublisherInstrumentation>(new EventStoreBusPublisherInstrumentation("worker", this.instrumentationEnabled));
             container.RegisterType<IEventStoreBusPublisher, EventStoreBusPublisher>(new ContainerControlledLifetimeManager());
             var cache = new MemoryCache("RepositoryCache");
             container.RegisterType(


### PR DESCRIPTION
Requires reinstalling the instrumentation.azure assembly.

Also changes the publisher perf counters to a multi instance counter, so the web app and the worker role have their own set of counters.
