### PR TITLE
Lowered SB prefetch count.

### DIFF
--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/SessionSubscriptionReceiver.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/SessionSubscriptionReceiver.cs
@@ -91,7 +91,14 @@ namespace Infrastructure.Azure.Messaging
 
             var messagingFactory = MessagingFactory.Create(this.serviceUri, tokenProvider);
             this.client = messagingFactory.CreateSubscriptionClient(topic, subscription);
-            this.client.PrefetchCount = 50;
+            if (this.requiresSequentialProcessing)
+            {
+                this.client.PrefetchCount = 10;
+            }
+            else
+            {
+                this.client.PrefetchCount = 15;
+            }
 
             this.dynamicThrottling =
                 new DynamicThrottling(

--- a/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/SubscriptionReceiver.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/Messaging/SubscriptionReceiver.cs
@@ -95,7 +95,14 @@ namespace Infrastructure.Azure.Messaging
 
             var messagingFactory = MessagingFactory.Create(this.serviceUri, tokenProvider);
             this.client = messagingFactory.CreateSubscriptionClient(topic, subscription);
-            this.client.PrefetchCount = 50;
+            if (this.processInParallel)
+            {
+                this.client.PrefetchCount = 18;
+            }
+            else
+            {
+                this.client.PrefetchCount = 14;
+            }
 
             this.dynamicThrottling =
                 new DynamicThrottling(


### PR DESCRIPTION
To allow for scaling out more appropriately and not reprocessing message due to locks lost when under stress.
