### PR TITLE
Migration tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ _UpgradeReport_Files
 /source/Infrastructure/Azure/Settings.xml
 /source/Conference.Azure/csx/
 /source/Migrations/MigrationToV2.Azure/csx/
+/source/Migrations/MigrationToV3.Azure/csx/
 *.build.csdef
 *crunch*

--- a/source/Conference/Conference.Web.Public/Global.asax.Azure.cs
+++ b/source/Conference/Conference.Web.Public/Global.asax.Azure.cs
@@ -58,7 +58,10 @@ namespace Conference.Web.Public
             // command bus
 
             var settings = InfrastructureSettings.Read(HttpContext.Current.Server.MapPath(@"~\bin\Settings.xml"));
-            new ServiceBusConfig(settings.ServiceBus).Initialize();
+            if (!Conference.Common.MaintenanceMode.IsInMaintainanceMode)
+            {
+                new ServiceBusConfig(settings.ServiceBus).Initialize();
+            }
             var commandBus = new CommandBus(new TopicSender(settings.ServiceBus, "conference/commands"), metadata, serializer);
 
             var synchronousCommandBus = new SynchronousCommandBusDecorator(commandBus);

--- a/source/Conference/Conference.Web.Public/Global.asax.cs
+++ b/source/Conference/Conference.Web.Public/Global.asax.cs
@@ -13,15 +13,12 @@
 
 namespace Conference.Web.Public
 {
-    using System.Linq;
     using System.Runtime.Caching;
     using System.Web;
     using System.Web.Mvc;
     using System.Web.Routing;
     using Conference.Common;
     using Conference.Web.Utils;
-    using Infrastructure.BlobStorage;
-    using Infrastructure.Sql.BlobStorage;
     using Microsoft.Practices.Unity;
     using Microsoft.WindowsAzure.ServiceRuntime;
     using Payments.ReadModel;
@@ -45,15 +42,7 @@ namespace Conference.Web.Public
             RoleEnvironment.Changed +=
                 (s, a) =>
                 {
-                    var changes = a.Changes.OfType<RoleEnvironmentConfigurationSettingChange>().ToList();
-                    if (changes.Any(x => x.ConfigurationSettingName != MaintenanceMode.MaintenanceModeSettingName))
-                    {
-                        RoleEnvironment.RequestRecycle();
-                    }
-                    else if (changes.Any(x => x.ConfigurationSettingName == MaintenanceMode.MaintenanceModeSettingName))
-                    {
-                        MaintenanceMode.RefreshIsInMaintainanceMode();
-                    }
+                    RoleEnvironment.RequestRecycle();
                 };
             MaintenanceMode.RefreshIsInMaintainanceMode();
 

--- a/source/Conference/Registration/Database/RegistrationProcessManagerDbContextInitializer.cs
+++ b/source/Conference/Registration/Database/RegistrationProcessManagerDbContextInitializer.cs
@@ -37,13 +37,13 @@ namespace Registration.Database
         public static void CreateIndexes(DbContext context)
         {
             context.Database.ExecuteSqlCommand(@"
-IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = 'IX_RegistrationProcessManager_Completed')
+IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name = 'IX_RegistrationProcessManager_Completed')
 CREATE NONCLUSTERED INDEX IX_RegistrationProcessManager_Completed ON [" + RegistrationProcessManagerDbContext.SchemaName + @"].[RegistrationProcess]( Completed )
             
-IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = 'IX_RegistrationProcessManager_OrderId')
+IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name = 'IX_RegistrationProcessManager_OrderId')
 CREATE NONCLUSTERED INDEX IX_RegistrationProcessManager_OrderId ON [" + RegistrationProcessManagerDbContext.SchemaName + @"].[RegistrationProcess]( OrderId )");
 
-//IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = 'IX_RegistrationProcessManager_ReservationId')
+//IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name = 'IX_RegistrationProcessManager_ReservationId')
 //CREATE NONCLUSTERED INDEX IX_RegistrationProcessManager_ReservationId ON [" + RegistrationProcessDbContext.SchemaName + @"].[RegistrationProcess]( ReservationId )
         }
     }

--- a/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContextInitializer.cs
+++ b/source/Conference/Registration/ReadModel/Implementation/ConferenceRegistrationDbContextInitializer.cs
@@ -37,7 +37,7 @@ namespace Registration.ReadModel.Implementation
         public static void CreateIndexes(DbContext context)
         {
             context.Database.ExecuteSqlCommand(@"
-IF NOT EXISTS (SELECT name FROM sysindexes WHERE name = 'IX_SeatTypesView_ConferenceId')
+IF NOT EXISTS (SELECT name FROM sys.indexes WHERE name = 'IX_SeatTypesView_ConferenceId')
 CREATE NONCLUSTERED INDEX IX_SeatTypesView_ConferenceId ON [" + ConferenceRegistrationDbContext.SchemaName + "].[ConferenceSeatTypesView]( ConferenceId )");
         }
     }


### PR DESCRIPTION
Changes the index creation to use views supported by sql azure.
Changes the way MaintenanceMode works in the web applications to prevent them from updating the subscriptions in maintenance mode. 
