### PR TITLE
Splitted topics and event stores for Orders and Seats Availability ARs.

### DIFF
--- a/source/Infrastructure/Azure/Infrastructure.Azure.Tests/InfrastructureSettingsFixture.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure.Tests/InfrastructureSettingsFixture.cs
@@ -28,9 +28,8 @@ namespace Infrastructure.Azure.Tests
             var settings = InfrastructureSettings.Read("Settings.Template.xml").ServiceBus;
 
             Assert.NotNull(settings);
-            Assert.Equal(2, settings.Topics.Count);
+            Assert.Equal(4, settings.Topics.Count);
             Assert.Equal(3, settings.Topics[0].Subscriptions.Count);
-            Assert.Equal(1, settings.Topics[0].MigrationSupport.Count);
         }
 
         [Fact]

--- a/source/Infrastructure/Azure/Infrastructure.Azure/EventSourcing/EventSourcingSettings.cs
+++ b/source/Infrastructure/Azure/Infrastructure.Azure/EventSourcing/EventSourcingSettings.cs
@@ -27,8 +27,13 @@ namespace Infrastructure.Azure.EventSourcing
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the Azure table used for Event Sourcing.
+        /// Gets or sets the name of the Windows Azure table used for the Orders and Seats Assignments Event Store.
         /// </summary>
-        public string TableName { get; set; }
+        public string OrdersTableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the Windows Azure table used for the Seats Availability Event Store.
+        /// </summary>
+        public string SeatsAvailabilityTableName { get; set; }
     }
 }

--- a/source/Infrastructure/Azure/Settings.Template.xml
+++ b/source/Infrastructure/Azure/Settings.Template.xml
@@ -13,44 +13,45 @@
         <Subscription Name="sessionless" RequiresSession="false" SqlFilter="TypeName NOT IN ('AddSeats','RemoveSeats','MakeSeatReservation','CommitSeatReservation','CancelSeatReservation')" />
         <Subscription Name="seatsavailability" RequiresSession="true" SqlFilter="TypeName IN ('AddSeats','RemoveSeats','MakeSeatReservation','CommitSeatReservation','CancelSeatReservation')" />
         <Subscription Name="log" RequiresSession="false"/>
-
-        <MigrationSupport>
-          <!-- stop using this subscription -->
-          <UpdateSubscriptionIfExists Name="all" SqlFilter="1=0"/>
-        </MigrationSupport>
       </Topic>
       <Topic Path="conference/events" IsEventBus="true">
         <Subscription Name="log" RequiresSession="false"/>
-        <Subscription Name="Registration.RegistrationPMOrderPlaced" RequiresSession="false" SqlFilter="TypeName IN ('OrderPlaced')"/>
-        <Subscription Name="Registration.RegistrationPMNextSteps" RequiresSession="false" SqlFilter="TypeName IN ('OrderUpdated','SeatsReserved','PaymentCompleted','OrderConfirmed')"/>
-        <Subscription Name="Registration.OrderViewModelGeneratorV3" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderUpdated','OrderPartiallyReserved','OrderReservationCompleted','OrderRegistrantAssigned','OrderConfirmed','OrderPaymentConfirmed')"/>
-        <Subscription Name="Registration.PricedOrderViewModelGeneratorV3" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderTotalsCalculated','OrderConfirmed','OrderExpired','SeatAssignmentsCreated','SeatCreated','SeatUpdated')"/>
-        <Subscription Name="Registration.ConferenceViewModelGenerator" RequiresSession="true" SqlFilter="TypeName IN ('ConferenceCreated','ConferenceUpdated','ConferencePublished','ConferenceUnpublished','SeatCreated','SeatUpdated','AvailableSeatsChanged','SeatsReserved','SeatsReservationCancelled')"/>
-        <Subscription Name="Registration.SeatAssignmentsViewModelGeneratorV3" RequiresSession="true" SqlFilter="TypeName IN ('SeatAssignmentsCreated','SeatAssigned','SeatUnassigned','SeatAssignmentUpdated')"/>
-        <Subscription Name="Registration.SeatAssignmentsHandler" RequiresSession="true" SqlFilter="TypeName IN ('OrderConfirmed','OrderPaymentConfirmed')"/>
-        <Subscription Name="Conference.OrderEventHandler" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderRegistrantAssigned','OrderTotalsCalculated','OrderConfirmed','OrderExpired','SeatAssignmentsCreated','SeatAssigned','SeatAssignmentUpdated','SeatUnassigned')"/>
-
-        <MigrationSupport>
-          <!-- stop using this subscription -->
-          <UpdateSubscriptionIfExists Name="Registration.RegistrationProcessRouter" SqlFilter="1=0"/>
-        </MigrationSupport>
+        <Subscription Name="Registration.RegistrationPMNextSteps" RequiresSession="false" SqlFilter="TypeName IN ('PaymentCompleted')"/>
+        <Subscription Name="Registration.PricedOrderViewModelGeneratorV3" RequiresSession="true" SqlFilter="TypeName IN ('SeatCreated','SeatUpdated')"/>
+        <Subscription Name="Registration.ConferenceViewModelGenerator" RequiresSession="true" SqlFilter="TypeName IN ('ConferenceCreated','ConferenceUpdated','ConferencePublished','ConferenceUnpublished','SeatCreated','SeatUpdated')"/>
+      </Topic>
+      <Topic Path="conference/eventsOrders" IsEventBus="true">
+        <Subscription Name="logOrders" RequiresSession="false"/>
+        <Subscription Name="Registration.RegistrationPMOrderPlacedOrders" RequiresSession="false" SqlFilter="TypeName IN ('OrderPlaced')"/>
+        <Subscription Name="Registration.RegistrationPMNextStepsOrders" RequiresSession="false" SqlFilter="TypeName IN ('OrderUpdated','OrderConfirmed')"/>
+        <Subscription Name="Registration.OrderViewModelGeneratorOrders" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderUpdated','OrderPartiallyReserved','OrderReservationCompleted','OrderRegistrantAssigned','OrderConfirmed','OrderPaymentConfirmed')"/>
+        <Subscription Name="Registration.PricedOrderViewModelOrders" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderTotalsCalculated','OrderConfirmed','OrderExpired','SeatAssignmentsCreated')"/>
+        <Subscription Name="Registration.SeatAssignmentsViewModelOrders" RequiresSession="true" SqlFilter="TypeName IN ('SeatAssignmentsCreated','SeatAssigned','SeatUnassigned','SeatAssignmentUpdated')"/>
+        <Subscription Name="Registration.SeatAssignmentsHandlerOrders" RequiresSession="true" SqlFilter="TypeName IN ('OrderConfirmed','OrderPaymentConfirmed')"/>
+        <Subscription Name="Conference.OrderEventHandlerOrders" RequiresSession="true" SqlFilter="TypeName IN ('OrderPlaced','OrderRegistrantAssigned','OrderTotalsCalculated','OrderConfirmed','OrderExpired','SeatAssignmentsCreated','SeatAssigned','SeatAssignmentUpdated','SeatUnassigned')"/>
+      </Topic>
+      <Topic Path="conference/eventsAvailability" IsEventBus="true">
+        <Subscription Name="logAvail" RequiresSession="false"/>
+        <Subscription Name="Registration.RegistrationPMNextStepsAvail" RequiresSession="false" SqlFilter="TypeName IN ('SeatsReserved')"/>
+        <Subscription Name="Registration.ConferenceViewModelAvail" RequiresSession="true" SqlFilter="TypeName IN ('AvailableSeatsChanged','SeatsReserved','SeatsReservationCancelled')"/>
       </Topic>
     </Topics>
   </ServiceBus>
   <EventSourcing>
-    <!-- Use a valid Azure storage account, as the development storage emulator does not support entity projections, which we are using in the Event Store -->
+    <!-- Use a valid Windows Azure storage account, as the development storage emulator does not support entity projections, which we are using in the Event Store -->
     <ConnectionString>DefaultEndpointsProtocol=https;AccountName=[YOUR_ACCOUNT_NAME];AccountKey=[YOUR_ACCOUNT_KEY]</ConnectionString>
-    <!-- Table name in Azure has restrictions: Only Alphanumeric Characters, Case-Insensitive, 3 to 63 Characters, May Not Begin With a Numeric Character -->
-    <TableName>ConferenceEventStore</TableName>
+    <!-- Table name in Windows Azure has restrictions: Only Alphanumeric Characters, Case-Insensitive, 3 to 63 Characters, May Not Begin With a Numeric Character -->
+    <OrdersTableName>ConferenceEventStoreOrders</OrdersTableName>
+    <SeatsAvailabilityTableName>ConferenceEventStoreSeats</SeatsAvailabilityTableName>
   </EventSourcing>
   <MessageLog>
     <ConnectionString>DefaultEndpointsProtocol=https;AccountName=[YOUR_ACCOUNT_NAME];AccountKey=[YOUR_ACCOUNT_KEY]</ConnectionString>
-    <!-- Table name in Azure has restrictions: Only Alphanumeric Characters, Case-Insensitive, 3 to 63 Characters, May Not Begin With a Numeric Character -->
+    <!-- Table name in Windows Azure has restrictions: Only Alphanumeric Characters, Case-Insensitive, 3 to 63 Characters, May Not Begin With a Numeric Character -->
     <TableName>ConferenceMessageLog</TableName>
   </MessageLog>
   <BlobStorage>
     <ConnectionString>DefaultEndpointsProtocol=https;AccountName=[YOUR_ACCOUNT_NAME];AccountKey=[YOUR_ACCOUNT_KEY]</ConnectionString>
-    <!-- Container name in Azure has restrictions: Only Lower-case Alphanumeric Characters and Dashes, 3 to 63 Characters, May Not Begin a Dash, May Not Contain Two Consecutive Dashes -->
+    <!-- Container name in Windows Azure has restrictions: Only Lower-case Alphanumeric Characters and Dashes, 3 to 63 Characters, May Not Begin a Dash, May Not Contain Two Consecutive Dashes -->
     <RootContainerName>conference-read-model</RootContainerName>
- </BlobStorage>
+  </BlobStorage>
 </InfrastructureSettings>

--- a/source/Infrastructure/Azure/Settings.xsd
+++ b/source/Infrastructure/Azure/Settings.xsd
@@ -54,7 +54,8 @@
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element name="ConnectionString" type="xs:string" minOccurs="1" maxOccurs="1" />
-                            <xs:element name="TableName" type="cqrs:AzureTableName" minOccurs="1" maxOccurs="1" />
+                            <xs:element name="OrdersTableName" type="cqrs:WindowsAzureTableName" minOccurs="1" maxOccurs="1" />
+                            <xs:element name="SeatsAvailabilityTableName" type="cqrs:WindowsAzureTableName" minOccurs="1" maxOccurs="1" />
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -62,7 +63,7 @@
                     <xs:complexType>
                         <xs:sequence>
                             <xs:element name="ConnectionString" type="xs:string" minOccurs="1" maxOccurs="1" />
-                            <xs:element name="TableName" type="cqrs:AzureTableName" minOccurs="1" maxOccurs="1" />
+                            <xs:element name="TableName" type="cqrs:WindowsAzureTableName" minOccurs="1" maxOccurs="1" />
                         </xs:sequence>
                     </xs:complexType>
                 </xs:element>
@@ -77,7 +78,7 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    <xs:simpleType name="AzureTableName">
+    <xs:simpleType name="WindowsAzureTableName">
         <xs:restriction base="xs:string">
             <!-- There is no way to annotate or render a more user-friendly error when pattern matching fails -->
             <xs:pattern value="^[A-Za-z][A-Za-z0-9]{2,62}$" />

--- a/source/WorkerRoleCommandProcessor/ServiceBusConstants.cs
+++ b/source/WorkerRoleCommandProcessor/ServiceBusConstants.cs
@@ -53,17 +53,9 @@ namespace WorkerRoleCommandProcessor
 				/// </summary>
 				public const string Log = "log";
 				/// <summary>
-				/// Registration.RegistrationPMOrderPlaced
-				/// </summary>
-				public const string RegistrationPMOrderPlaced = "Registration.RegistrationPMOrderPlaced";
-				/// <summary>
 				/// Registration.RegistrationPMNextSteps
 				/// </summary>
 				public const string RegistrationPMNextSteps = "Registration.RegistrationPMNextSteps";
-				/// <summary>
-				/// Registration.OrderViewModelGeneratorV3
-				/// </summary>
-				public const string OrderViewModelGeneratorV3 = "Registration.OrderViewModelGeneratorV3";
 				/// <summary>
 				/// Registration.PricedOrderViewModelGeneratorV3
 				/// </summary>
@@ -72,18 +64,74 @@ namespace WorkerRoleCommandProcessor
 				/// Registration.ConferenceViewModelGenerator
 				/// </summary>
 				public const string ConferenceViewModelGenerator = "Registration.ConferenceViewModelGenerator";
+			}
+		}
+
+		public static class EventsOrders
+		{
+			/// <summary>
+			/// conference/eventsOrders
+			/// </summary>
+			public const string Path = "conference/eventsOrders";
+
+			public static class Subscriptions
+			{
 				/// <summary>
-				/// Registration.SeatAssignmentsViewModelGeneratorV3
+				/// logOrders
 				/// </summary>
-				public const string SeatAssignmentsViewModelGeneratorV3 = "Registration.SeatAssignmentsViewModelGeneratorV3";
+				public const string LogOrders = "logOrders";
 				/// <summary>
-				/// Registration.SeatAssignmentsHandler
+				/// Registration.RegistrationPMOrderPlacedOrders
 				/// </summary>
-				public const string SeatAssignmentsHandler = "Registration.SeatAssignmentsHandler";
+				public const string RegistrationPMOrderPlacedOrders = "Registration.RegistrationPMOrderPlacedOrders";
 				/// <summary>
-				/// Conference.OrderEventHandler
+				/// Registration.RegistrationPMNextStepsOrders
 				/// </summary>
-				public const string OrderEventHandler = "Conference.OrderEventHandler";
+				public const string RegistrationPMNextStepsOrders = "Registration.RegistrationPMNextStepsOrders";
+				/// <summary>
+				/// Registration.OrderViewModelGeneratorOrders
+				/// </summary>
+				public const string OrderViewModelGeneratorOrders = "Registration.OrderViewModelGeneratorOrders";
+				/// <summary>
+				/// Registration.PricedOrderViewModelOrders
+				/// </summary>
+				public const string PricedOrderViewModelOrders = "Registration.PricedOrderViewModelOrders";
+				/// <summary>
+				/// Registration.SeatAssignmentsViewModelOrders
+				/// </summary>
+				public const string SeatAssignmentsViewModelOrders = "Registration.SeatAssignmentsViewModelOrders";
+				/// <summary>
+				/// Registration.SeatAssignmentsHandlerOrders
+				/// </summary>
+				public const string SeatAssignmentsHandlerOrders = "Registration.SeatAssignmentsHandlerOrders";
+				/// <summary>
+				/// Conference.OrderEventHandlerOrders
+				/// </summary>
+				public const string OrderEventHandlerOrders = "Conference.OrderEventHandlerOrders";
+			}
+		}
+
+		public static class EventsAvailability
+		{
+			/// <summary>
+			/// conference/eventsAvailability
+			/// </summary>
+			public const string Path = "conference/eventsAvailability";
+
+			public static class Subscriptions
+			{
+				/// <summary>
+				/// logAvail
+				/// </summary>
+				public const string LogAvail = "logAvail";
+				/// <summary>
+				/// Registration.RegistrationPMNextStepsAvail
+				/// </summary>
+				public const string RegistrationPMNextStepsAvail = "Registration.RegistrationPMNextStepsAvail";
+				/// <summary>
+				/// Registration.ConferenceViewModelAvail
+				/// </summary>
+				public const string ConferenceViewModelAvail = "Registration.ConferenceViewModelAvail";
 			}
 		}
 


### PR DESCRIPTION
This is to scale out the service bus and the event store. There is no reason why they should be using the same service entities.
